### PR TITLE
fix: homepage contents

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,19 +68,6 @@ const config = {
           alt: "CityLAB Icon",
           src: "img/citylab_icon_outlines.svg",
         },
-        items: [
-          {
-            type: "docSidebar",
-            sidebarId: "tutorialSidebar",
-            position: "left",
-            label: "Leitfaden",
-          },
-          {
-            href: "https://citylab-berlin.org/de/wissensspeicher/",
-            position: "left",
-            label: "Weitere Ressourcen",
-          },
-        ],
       },
       footer: {
         style: "light",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ export default function Home(): JSX.Element {
               <h1 className={styles.headline}>{siteConfig.title}</h1>
               <p className={styles.tagline}>{siteConfig.tagline}</p>
               <a href="/docs/einfuehrung" className={styles.button}>
-                Zur Einführung
+                Zum Leitfaden
               </a>
             </div>
             <img src="/img/agile-viz.svg" alt="" className={styles.viz} />


### PR DESCRIPTION
This PR:
- changes the wording of the homepage button to "Zum Leitfaden"
- removes the unnecessary nav items